### PR TITLE
chore(deps): update various dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,12 @@ name = "receipts"
 version = "0.1.0"
 
 [dependencies]
-lazy_static = "1.4.0"
+lazy_static = "1.4"
 primitive-types = "0.12"
 rand = "0.8"
-secp256k1 = { version = "0.24", features = ["recovery"] }
+secp256k1 = { version = "0.28", features = ["recovery"] }
 tiny-keccak = { version = "2", features = ["keccak"] }
-itertools = "0.10"
+itertools = "0.12"
 
 [dev-dependencies]
 rustc-hex = "2"

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -52,7 +52,7 @@ impl fmt::Display for SignError {
 }
 
 pub fn sign(data: &[u8], signer: &SecretKey) -> Result<Signature, SignError> {
-    let message = Message::from_slice(&hash_bytes(data)).unwrap();
+    let message = Message::from_digest_slice(&hash_bytes(data)).unwrap();
 
     let signature = SECP256K1.sign_ecdsa_recoverable(&message, signer);
     let (recovery_id, signature) = signature.serialize_compact();

--- a/src/voucher.rs
+++ b/src/voucher.rs
@@ -168,7 +168,7 @@ fn verify_receipts(
         let mut message = Bytes32::default();
         hasher.finalize(&mut message);
 
-        let message = Message::from_slice(&message).unwrap();
+        let message = Message::from_digest_slice(&message).unwrap();
         let signature = ecdsa::Signature::from_compact(&receipt.signature[..64])
             .map_err(|_| VoucherError::InvalidData)?;
         SECP256K1
@@ -222,7 +222,7 @@ pub fn combine_partial_vouchers(
         let mut message = Bytes32::default();
         hasher.finalize(&mut message);
 
-        let message = Message::from_slice(&message).unwrap();
+        let message = Message::from_digest_slice(&message).unwrap();
         let signature = ecdsa::Signature::from_compact(&partial_voucher.voucher.signature[..64])
             .map_err(|_| VoucherError::InvalidData)?;
         SECP256K1


### PR DESCRIPTION
This PR updates some of the crate dependencies to its latest versions.

> [!NOTE]
> This is required to update the `secp2546k1` crate version in the graph-gateway crate.