### PR TITLE
chore(deps): update rust crate secp256k1 to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 lazy_static = "1.4"
 primitive-types = "0.12"
 rand = "0.8"
-secp256k1 = { version = "0.28", features = ["recovery"] }
+secp256k1 = { version = "0.29", features = ["recovery"] }
 tiny-keccak = { version = "2", features = ["keccak"] }
 itertools = "0.12"
 


### PR DESCRIPTION
This PR updates some of the crate dependencies to its latest versions.

> [!NOTE]
> This is required to update the `secp2546k1` crate version in the graph-gateway crate.