### PR TITLE
Useful Error Variants for Vouchers in the Gateway

### DIFF
--- a/src/voucher.rs
+++ b/src/voucher.rs
@@ -15,6 +15,7 @@ pub enum VoucherError {
     UnorderedPartialVouchers,
     NoValue,
     InvalidRecoveryId,
+    VoucherValueTooLarge,
 }
 
 impl std::error::Error for VoucherError {}
@@ -29,6 +30,7 @@ impl fmt::Display for VoucherError {
             Self::UnorderedPartialVouchers => write!(f, "Unordered partial vouchers"),
             Self::NoValue => write!(f, "Receipts have no value"),
             Self::InvalidRecoveryId => SignError::InvalidRecoveryId.fmt(f),
+            Self::VoucherValueTooLarge => write!(f, "Voucher value too large"),
         }
     }
 }

--- a/src/voucher.rs
+++ b/src/voucher.rs
@@ -10,6 +10,7 @@ use crate::prelude::*;
 pub enum VoucherError {
     InvalidData,
     InvalidSignature,
+    JsonDeserialization(String),
     UnorderedReceipts,
     UnorderedPartialVouchers,
     NoValue,
@@ -23,6 +24,7 @@ impl fmt::Display for VoucherError {
         match self {
             Self::InvalidData => write!(f, "Invalid receipts data"),
             Self::InvalidSignature => write!(f, "Receipts are not signed for the given allocation"),
+            Self::JsonDeserialization(err) => write!(f, "JSON error: {}", err),
             Self::UnorderedReceipts => write!(f, "Unordered receipts"),
             Self::UnorderedPartialVouchers => write!(f, "Unordered partial vouchers"),
             Self::NoValue => write!(f, "Receipts have no value"),


### PR DESCRIPTION
This PR would add `VoucherError` variants useful for the Gateway, for example [here](https://github.com/edgeandnode/gateway/blob/8c3109e9198145ffb87e3f443cb4ee5edfc445b9/src/vouchers.rs#L37) and [here](https://github.com/edgeandnode/gateway/blob/8c3109e9198145ffb87e3f443cb4ee5edfc445b9/src/vouchers.rs#L128), where we currently need to use `String` for the error type to gain custom handling.
I've used `String` for the `JsonDeserialization` variant to avoid adding `serde_json` as a dependency.

Signed off by Joseph Livesey <joseph@semiotic.ai>